### PR TITLE
CMake 4 compat: drop CMP0003 OLD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,8 @@
 # Vladimir S. FONOV - vladimir.fonov@gmail.com
 # 
+CMAKE_MINIMUM_REQUIRED(VERSION 3.10)
 PROJECT (PATCH_MORPHOLOGY)
 ENABLE_TESTING()
-
-CMAKE_MINIMUM_REQUIRED(VERSION 3.10)
-if(COMMAND cmake_policy)
- cmake_policy(SET CMP0003 OLD)
-endif(COMMAND cmake_policy)
 
 IF(NOT MINC_TOOLKIT_BUILD)
   # ITK is optional: probe for it but do not require.


### PR DESCRIPTION
## Problem

CMake 4.x removes support for setting old policies to `OLD`, so the top-level `cmake_policy(SET CMP0003 OLD)` is now a hard configure error:

```
CMake Error at CMakeLists.txt (cmake_policy):
  Policy CMP0003 may not be set to OLD behavior because this version
  of CMake no longer supports it.
```

This breaks the build on any CMake 4.x toolchain (e.g. Ubuntu 26.04, Fedora 42+, recent Homebrew), including as a minc-toolkit-v2 submodule.

## Fix

- Remove the `cmake_policy(SET CMP0003 OLD)` block. CMP0003 (full-path libraries do not add linker search paths) dates to CMake 2.6; its NEW behavior has been the default for ~15 years, so the OLD setting is dead weight — removing it is behavior-neutral on any modern CMake.
- Move `CMAKE_MINIMUM_REQUIRED` ahead of `PROJECT()` to silence the `cmake_minimum_required() should be called prior to this top-level project()` deprecation warning.

Configures cleanly under CMake 4.3 / GCC 16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)